### PR TITLE
fix: return URL with trailing slash

### DIFF
--- a/src/url-utils.js
+++ b/src/url-utils.js
@@ -18,7 +18,7 @@ const gatewayHttpUrl = (cid, gatewayProvider = 'ipfs') => {
     return origin
   }
 
-  return `${origin}/ipfs/${cid}`
+  return `${origin}/ipfs/${cid}/`
 }
 
 const linkCid = (cid, gatewayProvider) => `🔗  ${chalk.green(

--- a/test/url-utils.js
+++ b/test/url-utils.js
@@ -3,19 +3,19 @@ const proxyquire = require('proxyquire').noCallThru()
 const { gatewayHttpUrl } = require('../src/url-utils')
 
 test('get http gateway url for a cid', t => {
-  const expected = 'https://ipfs.io/ipfs/fakecid'
+  const expected = 'https://ipfs.io/ipfs/fakecid/'
   const actual = gatewayHttpUrl('fakecid')
   t.is(actual, expected)
 })
 
 test('get http gateway url for a cid on infura', t => {
-  const expected = 'https://ipfs.infura.io/ipfs/fakecid'
+  const expected = 'https://ipfs.infura.io/ipfs/fakecid/'
   const actual = gatewayHttpUrl('fakecid', 'infura')
   t.is(actual, expected)
 })
 
 test('get http gateway url for a cid on pinata', t => {
-  const expected = 'https://gateway.pinata.cloud/ipfs/fakecid'
+  const expected = 'https://gateway.pinata.cloud/ipfs/fakecid/'
   const actual = gatewayHttpUrl('fakecid', 'pinata')
   t.is(actual, expected)
 })


### PR DESCRIPTION
> This is a fix for https://github.com/ipfs-shipyard/ipfs-deploy/issues/86#issuecomment-528697472 (thx @autonome for debugging this!)

This PR removes the need for HTTP 301 (internal redirect done by go-ipfs when slash is missing) and closes #86 on gateways that override that disabled the mentioned redirect.


@hacdias I believe this should be released as a patch version, thanks! 