### PR TITLE
feat(dnslink): add DNSimple as a supported DNS service

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,42 @@ IPFS_DEPLOY_CLOUDFLARE__RECORD=_dnslink.mysubdomain.agentofuser.com
 
 Use flag `-d cloudflare`.
 
+#### [DNSimple](https://dnsimple.com)
+
+DNSimple is a paid-for DNS provider. They have no specific IPFS support,
+but allow the setting of DNS TXT records which underlies [IPFS DNSLink](https://docs.ipfs.io/guides/concepts/dnslink/).
+
+##### Environment variables
+
+```bash
+# credentials
+IPFS_DEPLOY_DNSIMPLE__TOKEN=
+
+# dns info
+IPFS_DEPLOY_DNSIMPLE__ZONE=
+IPFS_DEPLOY_DNSIMPLE__RECORD=
+```
+
+Example with top-level domain:
+
+```bash
+# dnsimple dns info
+IPFS_DEPLOY_DNSIMPLE__ZONE=agentofuser.com
+IPFS_DEPLOY_DNSIMPLE__RECORD=_dnslink.agentofuser.com
+```
+
+Example with subdomain:
+
+```bash
+# dnsimple dns info
+IPFS_DEPLOY_DNSIMPLE__ZONE=agentofuser.com
+IPFS_DEPLOY_DNSIMPLE__RECORD=_dnslink.mysubdomain.agentofuser.com
+```
+
+##### How to enable
+
+Use flag `-d dnsimple`.
+
 ## API
 
 This is still pretty unstable and subject to change, so I will just show how
@@ -231,6 +267,11 @@ const deploy = require('ipfs-deploy')
           apiEmail: argv.cloudflare && argv.cloudflare.apiEmail,
           zone: argv.cloudflare && argv.cloudflare.zone,
           record: argv.cloudflare && argv.cloudflare.record,
+        },
+        dnsimple: {
+          token: argv.dnsimple && argv.dnsimple.token,
+          zone: argv.dnsimple && argv.dnsimple.zone,
+          record: argv.dnsimple && argv.dnsimple.record
         },
         pinata: {
           apiKey: argv.pinata && argv.pinata.apiKey,

--- a/bin/ipfs-deploy.js
+++ b/bin/ipfs-deploy.js
@@ -11,7 +11,7 @@ require('dotenv').config()
 
 const pinProviders = ['pinata', 'infura', 'ipfs-cluster', 'fission']
 
-const dnsProviders = ['cloudflare']
+const dnsProviders = ['cloudflare', 'dnsimple']
 
 const argv = yargs
   .scriptName('ipfs-deploy')
@@ -99,6 +99,11 @@ async function main () {
         apiEmail: argv.cloudflare && argv.cloudflare.apiEmail,
         zone: argv.cloudflare && argv.cloudflare.zone,
         record: argv.cloudflare && argv.cloudflare.record
+      },
+      dnsimple: {
+        token: argv.dnsimple && argv.dnsimple.token,
+        zone: argv.dnsimple && argv.dnsimple.zone,
+        record: argv.dnsimple && argv.dnsimple.record
       },
       pinata: {
         apiKey: argv.pinata && argv.pinata.apiKey,

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "colors": "^1.4.0",
     "common-tags": "^2.0.0-alpha.1",
     "dnslink-cloudflare": "^2.0.3",
+    "dnslink-dnsimple": "^1.0.1",
     "dotenv": "^8.2.0",
     "form-data": "^2.5.1",
     "ipfs-cluster-api": "0.0.9",

--- a/src/dnslink/dnsimple.js
+++ b/src/dnslink/dnsimple.js
@@ -1,0 +1,40 @@
+const dnslink = require('dnslink-dnsimple')
+const _ = require('lodash')
+const fp = require('lodash/fp')
+
+module.exports = {
+  name: 'DNSimple',
+  validate: ({ token, zone, record } = {}) => {
+    if (_.isEmpty(token)) {
+      throw new Error(`Missing the following environment variables:
+
+IPFS_DEPLOY_DNSIMPLE__TOKEN`)
+    }
+
+    if (fp.some(_.isEmpty)([zone, record])) {
+      throw new Error(`Missing the following environment variables:
+  
+IPFS_DEPLOY_DNSIMPLE__ZONE
+IPFS_DEPLOY_DNSIMPLE__RECORD`)
+    }
+  },
+  link: async (_domain, hash, { token, zone, record }) => {
+    const recordWithoutZone = record.replace(`.${zone}`, '')
+
+    const flags = {
+      domain: zone,
+      record: recordWithoutZone,
+      link: `/ipfs/${hash}`,
+      ttl: 60
+    }
+
+    const {
+      record: { content }
+    } = await dnslink(token, flags)
+
+    return {
+      record: `${recordWithoutZone}.${zone}`,
+      value: content
+    }
+  }
+}

--- a/src/dnslink/index.js
+++ b/src/dnslink/index.js
@@ -1,5 +1,6 @@
 const make = require('./maker')
 
 module.exports = {
-  cloudflare: make(require('./cloudflare'))
+  cloudflare: make(require('./cloudflare')),
+  dnsimple: make(require('./dnsimple'))
 }

--- a/test/dnslink/dnsimple.js
+++ b/test/dnslink/dnsimple.js
@@ -1,0 +1,40 @@
+const test = require('ava')
+const proxyquire = require('proxyquire').noCallThru()
+const { hasRightFormat } = require('./helpers')
+
+const dnsimple = proxyquire('../../src/dnslink/dnsimple', {
+  'dnslink-dnsimple': (_token, { link }) => {
+    return { record: { content: `dnslink=${link}` } }
+  }
+})
+
+test('dnsimple has right format', t => {
+  t.is(hasRightFormat(dnsimple), true)
+})
+
+test('validate throws on wrong options', t => {
+  t.throws(() => {
+    dnsimple.validate({})
+  })
+})
+
+test('validate succeeds on correct options', t => {
+  t.notThrows(() => {
+    dnsimple.validate({
+      token: 'XXXXXXXXXXXXXXX',
+      zone: 'example.com',
+      record: '_dnslink'
+    })
+  })
+})
+
+test('link returns correct output', async t => {
+  const res = await dnsimple.link('example.com', 'QmHash', {
+    token: 'XXXXXXXXXXXXXXX',
+    zone: 'example.com',
+    record: '_dnslink.example.com'
+  })
+
+  t.is(res.record, '_dnslink.example.com')
+  t.is(res.value, 'dnslink=/ipfs/QmHash')
+})


### PR DESCRIPTION
The DNSimple functionality is provided by `js-dnslink-dnsimple`. The environment variables are named to closely match the `cloudflare` example.

Fixes #3