### PR TITLE
Hexo uses ./public

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,10 +75,9 @@ site generators by the following order:
 | --------        | ---------------------------------       |
 | `_site`         | jekyll, hakyll, eleventy                |
 | `site`          | some others                             |
-| `public`        | gatsby, hugo                            |
+| `public`        | gatsby, hugo, hexo                      |
 | `dist`          | nuxt                                    |
 | `output`        | pelican                                 |
-| `out`           | hexo                                    |
 | `build`         | create-react-app, metalsmith, middleman |
 | `website/build` | docusaurus                              |
 | `docs`          | many others                             |

--- a/src/guess-path.js
+++ b/src/guess-path.js
@@ -10,13 +10,13 @@ function guessedPath () {
   const guesses = [
     '_site', // jekyll, hakyll, eleventy
     'site', // forgot which
-    'public', // gatsby, hugo
+    'public', // gatsby, hugo, hexo
     'dist', // nuxt
     'output', // pelican
-    'out', // hexo
     'build', // create-react-app, metalsmith, middleman
     'website/build', // docusaurus
-    'docs' // many others
+    'docs', // many others
+    'out' // unknown others
   ]
 
   return fp.filter(existsSync)(guesses)[0]


### PR DESCRIPTION
## What does it do?

It changes information about hexo that says it uses "./public" instead of "./out" for the static build path. I have contributed to hexo and I am in that org too. For the skeptical observer: https://hexo.io/docs/configuration#Directory

I can change the order, or note, or delete "out" if you want.

## How to test

The change is trivial and `54 tests passed` with no errors.

You can still test if you wish to.

```
# clone and test
git clone -b hexo-public-dir https://github.com/tcrowe/ipfs-deploy.git
cd ipfs-deploy
npm install
npm test

# optional cleanup
cd ..
rm -rf ipfs-deploy
```

---

Thanks & take care
-Tony