### PR TITLE
Typo fix: 'transfered' is transferred and 'ensable' is enable

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ site generators by the following order:
 Some pinning services and DNS providers require signup and additional
 environment variables to be set. We support and use `.env` files. Read
 the section bellow to find out about which services are supported and
-how to ensable them.
+how to enable them.
 
 For further information about the CLI, please run `ipfs-deploy --help`.
 
@@ -318,7 +318,7 @@ control.
 ### Contributors
 
 This project was initially started by [@agentofuser](https://github.com/agentofuser),
-who made a lot of awesome work in here. Posteriorly, it was transfered to ipfs-shipyard.
+who made a lot of awesome work in here. Posteriorly, it was transferred to ipfs-shipyard.
 Thanks for starting this awesome project!
 
 Everyone is welcome to contribute and add new features!


### PR DESCRIPTION
## What does it do?

transfered = transferred
ensable = enable

"Posteriorly" was too hard so it took brain bandwidth from the words nearby. 😉 

## How to test

(~~Markup~~ Markdown only)

👋 

-Tony