### PR TITLE
fix: adding --site-domain to --help

### DIFF
--- a/bin/ipfs-deploy.js
+++ b/bin/ipfs-deploy.js
@@ -37,6 +37,10 @@ const argv = yargs
             choices: dnsProviders,
             describe: 'DNS provider whose dnslink TXT field will be updated'
           },
+          f: {
+            alias: 'friendly-name',
+            describe: 'Name to pass through to pinning service. Useful when not wanting to use folder name.'
+          },
           O: {
             alias: 'no-open',
             describe: "DON'T open URL after deploying"
@@ -119,7 +123,8 @@ async function main () {
         username: argv.fission && argv.fission.username,
         password: argv.fission && argv.fission.password
       }
-    }
+    },
+    friendlyName: argv.friendlyName
   }
 
   if (typeof options.dnsProviders === 'string') {

--- a/bin/ipfs-deploy.js
+++ b/bin/ipfs-deploy.js
@@ -37,10 +37,6 @@ const argv = yargs
             choices: dnsProviders,
             describe: 'DNS provider whose dnslink TXT field will be updated'
           },
-          f: {
-            alias: 'friendly-name',
-            describe: 'Name to pass through to pinning service. Useful when not wanting to use folder name.'
-          },
           O: {
             alias: 'no-open',
             describe: "DON'T open URL after deploying"
@@ -123,8 +119,7 @@ async function main () {
         username: argv.fission && argv.fission.username,
         password: argv.fission && argv.fission.password
       }
-    },
-    friendlyName: argv.friendlyName
+    }
   }
 
   if (typeof options.dnsProviders === 'string') {

--- a/bin/ipfs-deploy.js
+++ b/bin/ipfs-deploy.js
@@ -49,6 +49,10 @@ const argv = yargs
               'path'
             )} will be uploaded`
           },
+          s: {
+            alias: 'site-domain',
+            describe: "Can be used as pin name in pinning services"
+          },
           u: {
             alias: 'unique-upload',
             choices: pinProviders,

--- a/bin/ipfs-deploy.js
+++ b/bin/ipfs-deploy.js
@@ -51,7 +51,7 @@ const argv = yargs
           },
           s: {
             alias: 'site-domain',
-            describe: "Can be used as pin name in pinning services"
+            describe: `Can be used as pin name in pinning services`
           },
           u: {
             alias: 'unique-upload',

--- a/bin/ipfs-deploy.js
+++ b/bin/ipfs-deploy.js
@@ -51,7 +51,7 @@ const argv = yargs
           },
           s: {
             alias: 'site-domain',
-            describe: `Can be used as pin name in pinning services`
+            describe: 'Can be used as pin name in pinning services'
           },
           u: {
             alias: 'unique-upload',

--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,8 @@ async function deploy ({
   remotePinners = ['infura'],
   dnsProviders = [],
   siteDomain,
-  credentials = {}
+  credentials = {},
+  friendlyName
 } = {}) {
   publicDirPath = guessPathIfEmpty(publicDirPath)
 
@@ -37,6 +38,7 @@ async function deploy ({
   }
 
   const tag =
+    friendlyName ||
     (credentials.cloudflare && credentials.cloudflare.record) ||
     siteDomain ||
     __dirname

--- a/src/index.js
+++ b/src/index.js
@@ -22,8 +22,7 @@ async function deploy ({
   remotePinners = ['infura'],
   dnsProviders = [],
   siteDomain,
-  credentials = {},
-  friendlyName
+  credentials = {}
 } = {}) {
   publicDirPath = guessPathIfEmpty(publicDirPath)
 
@@ -38,7 +37,6 @@ async function deploy ({
   }
 
   const tag =
-    friendlyName ||
     (credentials.cloudflare && credentials.cloudflare.record) ||
     siteDomain ||
     __dirname


### PR DESCRIPTION
When uploading to a service that uses the `tag` as metadata to label the pin, it defaults to using the full path of the folder e.g. `/mnt/c/source/...`

**What**
This PR adds information about `--site-domain` parameter that can be used to add a friendly name for the pin.

![image](https://user-images.githubusercontent.com/1320729/73039580-fcc66400-3e99-11ea-8521-aa702c5b1a51.png)


**Testing**
![image](https://user-images.githubusercontent.com/1320729/73039624-1ebfe680-3e9a-11ea-98c3-0667692767ff.png)

![image](https://user-images.githubusercontent.com/1320729/73039632-22536d80-3e9a-11ea-92e5-7e5162179f5f.png)
![image](https://user-images.githubusercontent.com/1320729/73039635-241d3100-3e9a-11ea-8231-b3e23773ec1c.png)
![image](https://user-images.githubusercontent.com/1320729/73039637-25e6f480-3e9a-11ea-8378-b3946c9b4728.png)
