### PR TITLE
feat: adds options to alter logging behavior

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 const _ = require('lodash')
-const { logError } = require('./logging')
+const { logger, logError } = require('./logging')
 
 const guessPathIfEmpty = require('./guess-path')
 const showSize = require('./show-size')
@@ -22,8 +22,8 @@ async function deploy ({
   dnsProviders = [],
   siteDomain,
   credentials = {},
-  logMessage = null,
-  logError = null
+  writeLog = null,
+  writeError = null
 } = {}) {
   publicDirPath = guessPathIfEmpty(publicDirPath)
 
@@ -31,7 +31,7 @@ async function deploy ({
     return undefined
   }
 
-  const readableSize = await showSize(publicDirPath, { logMessage, logError })
+  const readableSize = await showSize(publicDirPath, { writeLog, writeError })
 
   if (!readableSize) {
     return undefined
@@ -57,8 +57,8 @@ async function deploy ({
   for (const pinnerName of remotePinners) {
     const pinner = await pinnerProviders[_.camelCase(pinnerName)]({
       ...credentials[_.camelCase(pinnerName)],
-      logMessage,
-      logError
+      writeLog,
+      writeError
     })
 
     if (!pinner) {
@@ -83,7 +83,7 @@ async function deploy ({
   }
 
   if (!sameValues(pinnedHashes)) {
-    const log = logger({ logMessage, logError })
+    const log = logger({ writeLog, writeError })
     log.fail('≠  Found inconsistency in pinned hashes:')
     logError(pinnedHashes)
     return

--- a/src/logging.js
+++ b/src/logging.js
@@ -30,12 +30,12 @@ function logError (e) {
 }
 
 const logger = (options) => {
-  if (!(options.logError && options.logMessage)) {
+  if (!(options.writeError && options.writeLog)) {
     return ora()
   }
 
-  const stderr = options.logError ? options.logError : logError
-  const stdout = options.logMessage
+  const stderr = options.writeError ? options.writeError : logError
+  const stdout = options.writeLog
 
   return {
     fail: stderr,

--- a/src/logging.js
+++ b/src/logging.js
@@ -1,6 +1,7 @@
 const _ = require('lodash')
 const fp = require('lodash/fp')
 const neatFrame = require('neat-frame')
+const ora = require('ora')
 const { stripIndent } = require('common-tags')
 
 function formatError (e) {
@@ -28,4 +29,20 @@ function logError (e) {
   return errorString
 }
 
-module.exports = { formatError, logError }
+const logger = (options) => {
+  if (!(options.logError && options.logMessage)) {
+    return ora()
+  }
+
+  const stderr = options.logError ? options.logError : logError
+  const stdout = options.logMessage
+
+  return {
+    fail: stderr,
+    succeed: stdout,
+    info: stdout,
+    start: stdout
+  }
+}
+
+module.exports = { formatError, logError, logger }

--- a/src/pinners/maker.js
+++ b/src/pinners/maker.js
@@ -1,9 +1,9 @@
-const ora = require('ora')
 const colors = require('colors/safe')
 const _ = require('lodash')
-const { logError } = require('../logging')
+const { logger, logError } = require('../logging')
 const { linkCid } = require('../url-utils')
 const white = colors.brightWhite
+
 
 module.exports = ({ name, builder, pinDir, pinHash }) => async options => {
   const slug = _.toLower(name)
@@ -19,35 +19,35 @@ module.exports = ({ name, builder, pinDir, pinHash }) => async options => {
 
   return {
     pinDir: async (dir, tag) => {
-      const spinner = ora()
-      spinner.start(`📠  Uploading and pinning to ${name}…`)
+      const log = logger(options)
+      log.start(`📠  Uploading and pinning to ${name}…`)
 
       try {
         const hash = await pinDir(api, dir, tag)
 
-        spinner.succeed(`📌  Added and pinned to ${name} with hash:`)
-        spinner.info(linkCid(hash, slug))
+        log.succeed(`📌  Added and pinned to ${name} with hash:`)
+        log.info(linkCid(hash, slug))
 
         return hash
       } catch (error) {
-        spinner.fail(`💔  Uploading to ${name} didn't work.`)
+        log.fail(`💔  Uploading to ${name} didn't work.`)
         logError(error)
         return undefined
       }
     },
     pinHash: async (hash, tag) => {
-      const spinner = ora()
-      spinner.start(`📠  Pinning hash to ${name}…`)
+      const log = logger(options)
+      log.start(`📠  Pinning hash to ${name}…`)
 
       try {
         await pinHash(api, hash, tag)
 
-        spinner.succeed(`📌  Hash pinned to ${name}:`)
-        spinner.info(linkCid(hash, slug))
+        log.succeed(`📌  Hash pinned to ${name}:`)
+        log.info(linkCid(hash, slug))
 
         return hash
       } catch (error) {
-        spinner.fail(`💔  Pinning to ${name} didn't work.`)
+        log.fail(`💔  Pinning to ${name} didn't work.`)
         logError(error)
         return undefined
       }

--- a/src/pinners/maker.js
+++ b/src/pinners/maker.js
@@ -4,7 +4,6 @@ const { logger, logError } = require('../logging')
 const { linkCid } = require('../url-utils')
 const white = colors.brightWhite
 
-
 module.exports = ({ name, builder, pinDir, pinHash }) => async options => {
   const slug = _.toLower(name)
   name = white(name)

--- a/src/show-size.js
+++ b/src/show-size.js
@@ -1,14 +1,13 @@
 const util = require('util')
 const trammel = util.promisify(require('trammel'))
 const byteSize = require('byte-size')
-const ora = require('ora')
 const colors = require('colors/safe')
 
-const { logError } = require('./logging')
+const { logger, logError } = require('./logging')
 
-module.exports = async path => {
-  const spinner = ora()
-  spinner.start(`📦  Calculating size of ${colors.blue(path)}…`)
+module.exports = async (path, options) => {
+  const log = logger(options)
+  log.start(`📦  Calculating size of ${colors.blue(path)}…`)
   try {
     const size = await trammel(path, {
       stopOnError: true,
@@ -16,12 +15,12 @@ module.exports = async path => {
     })
     const kibi = byteSize(size, { units: 'iec' })
     const readableSize = `${kibi.value} ${kibi.unit}`
-    spinner.succeed(
+    log.succeed(
       `🚚  Directory ${colors.blue(path)} weighs ${readableSize}.`
     )
     return readableSize
   } catch (e) {
-    spinner.fail("⚖  Couldn't calculate website size.")
+    log.fail("⚖  Couldn't calculate website size.")
     logError(e)
     return undefined
   }


### PR DESCRIPTION
We're using this package as a library, not as a CLI utility.  The CLI spinner(ora) outputs everything to stderr making clean log parsing and error detection difficult.

This PR adds `writeLog` and `writeError` options to the main deploy function that when set will replace ora for log output.

Let me know if you have any feedback.  This (or something like it) would be pretty useful to us.