### PR TITLE
fix: pinata deploy error handling and 429 retries

### DIFF
--- a/src/pinners/pinata.js
+++ b/src/pinners/pinata.js
@@ -26,7 +26,7 @@ IPFS_DEPLOY_PINATA__SECRET_API_KEY`)
   pinDir: async ({ apiKey, secretApiKey }, dir, tag) => {
     dir = path.normalize(dir)
 
-    const { dirs, files } = await recursive.read(dir)
+    const { files } = await recursive.read(dir)
     const data = new FormData()
     const toStrip = path.dirname(dir).length
     files.forEach(file => {

--- a/test/pinners/pinata.js
+++ b/test/pinners/pinata.js
@@ -13,8 +13,8 @@ const getBuiltPinata = async (pinata) => {
 
 const getPinataNoThrow = () => proxyquire('../../src/pinners/pinata', {
   'recursive-fs': {
-    readdirr: (_, cb) => {
-      cb(null, null, [])
+    read: async (_) => {
+      return { files: [] }
     }
   },
   axios: {


### PR DESCRIPTION
This PR refactors the Pinata module a bit to use async/await for cleaner error bubbling and adds retries for 429 responses (rate limiting).

Let me know if you have any feedback.

Related: https://github.com/OriginProtocol/dshop/issues/812