### PR TITLE
DreamHost DNS support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,38 @@ IPFS_DEPLOY_DNSIMPLE__RECORD=_dnslink.mysubdomain.agentofuser.com
 
 Use flag `-d dnsimple`.
 
+#### [DreamHost](https://dreamhost.com)
+
+DreamHost is a paid-for web host. They have no specific IPFS support, but provide DNS services with API control. [DreamHost API](https://help.dreamhost.com/hc/en-us/sections/203903178-API-Application-Programming-Interface-).
+
+##### Environment variables
+
+```bash
+# credentials
+IPFS_DEPLOY_DREAMHOST__KEY=
+
+# dns info
+IPFS_DEPLOY_DREAMHOST__RECORD=
+```
+
+Example with top-level domain:
+
+```bash
+# dreamhost dns info
+IPFS_DEPLOY_DREAMHOST__RECORD=_dnslink.agentofuser.com
+```
+
+Example with subdomain:
+
+```bash
+# dreamhost dns info
+IPFS_DEPLOY_DNSIMPLE__RECORD=_dnslink.mysubdomain.agentofuser.com
+```
+
+##### How to enable
+
+Use flag `-d dreamhost`.
+
 ## API
 
 This is still pretty unstable and subject to change, so I will just show how

--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ Example with subdomain:
 
 ```bash
 # dreamhost dns info
-IPFS_DEPLOY_DNSIMPLE__RECORD=_dnslink.mysubdomain.agentofuser.com
+IPFS_DEPLOY_DREAMHOST__RECORD=_dnslink.mysubdomain.agentofuser.com
 ```
 
 ##### How to enable

--- a/bin/ipfs-deploy.js
+++ b/bin/ipfs-deploy.js
@@ -11,7 +11,7 @@ require('dotenv').config()
 
 const pinProviders = ['pinata', 'infura', 'ipfs-cluster', 'fission', 'dappnode']
 
-const dnsProviders = ['cloudflare', 'dnsimple']
+const dnsProviders = ['cloudflare', 'dnsimple', 'dreamhost']
 
 const argv = yargs
   .scriptName('ipfs-deploy')
@@ -109,6 +109,11 @@ async function main () {
         token: argv.dnsimple && argv.dnsimple.token,
         zone: argv.dnsimple && argv.dnsimple.zone,
         record: argv.dnsimple && argv.dnsimple.record
+      },
+      dreamhost: {
+        key: argv.dreamhost && argv.dreamhost.key,
+        zone: argv.dreamhost && argv.dreamhost.zone,
+        record: argv.dreamhost && argv.dreamhost.record
       },
       pinata: {
         apiKey: argv.pinata && argv.pinata.apiKey,

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "dnslink-cloudflare": "^3.0.0",
     "dnslink-dnsimple": "^1.0.1",
     "dotenv": "^8.2.0",
+    "dreamhost": "^1.0.5",
     "form-data": "^3.0.0",
     "ipfs-cluster-api": "0.0.9",
     "ipfs-http-client": "^45.0.0",

--- a/src/dnslink/dreamhost.js
+++ b/src/dnslink/dreamhost.js
@@ -1,0 +1,51 @@
+const DreamHost = require('dreamhost')
+const _ = require('lodash')
+const fp = require('lodash/fp')
+
+module.exports = {
+  name: 'DreamHost',
+  validate: ({ key, zone, record } = {}) => {
+    if (_.isEmpty(key)) {
+      throw new Error(`Missing the following environment variables:
+
+IPFS_DEPLOY_DREAMHOST__KEY`)
+    }
+
+    if (_.isEmpty(record)) {
+      throw new Error(`Missing the following environment variables:
+  
+IPFS_DEPLOY_DREAMHOST__RECORD`)
+    }
+  },
+  link: async (_domain, hash, { key, record }) => {
+    const link = `/ipfs/${hash}`;
+
+    const options = {
+        type: 'TXT',
+        record: record,
+        value: link,
+        comment: 'Added by ipfs-deploy.',
+    };
+
+    const dreamHost = new DreamHost({ key });
+    const records = await dreamHost.dns.listRecords();
+    const forDomain = _.filter(records, (o) => {
+        return (o.record == options.record
+                && o.type == options.type
+                && o.value.startsWith('/ipfs/'));
+    });
+    _.each(forDomain, async (o) => {
+        await dreamHost.dns.removeRecord({
+            type: o.type,
+            record: o.record,
+            value: o.value
+        });
+    });
+    const content = await dreamHost.dns.addRecord(options);
+
+    return {
+      record: record,
+      value: options.value
+    }
+  }
+}

--- a/src/dnslink/index.js
+++ b/src/dnslink/index.js
@@ -2,5 +2,6 @@ const make = require('./maker')
 
 module.exports = {
   cloudflare: make(require('./cloudflare')),
-  dnsimple: make(require('./dnsimple'))
+  dnsimple: make(require('./dnsimple')),
+  dreamhost: make(require('./dreamhost'))
 }


### PR DESCRIPTION
I added support for DreamHost's DNS API. There is already a node package for calling their API and I utilized that. I tested this with my own account and I am able to deploy and update dns using `ipfs-deploy`.

Let me know if I missed anything.