### PR TITLE
fix: site-domain parameter when using cloudflare

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -38,8 +38,8 @@ async function deploy ({
   }
 
   const tag =
-    (credentials.cloudflare && credentials.cloudflare.record) ||
     siteDomain ||
+    (credentials.cloudflare && credentials.cloudflare.record) ||
     __dirname
 
   if (uniqueUpload) {


### PR DESCRIPTION
Problem: 
The `site-domain` parameter is not used when using cloudflare as a dns provider.
As a result the pinned files and folders are all named  or has the prefix '_dnslink' on pinata.

Solution:
Change the logic and use the site-domain parameter first, if it's set.

Testing:
No testing, since the change is too simple.