### PR TITLE
refactor: use chalk

### DIFF
--- a/bin/ipfs-deploy.js
+++ b/bin/ipfs-deploy.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 const updateNotifier = require('update-notifier')
-const colors = require('colors/safe')
+const chalk = require('chalk')
 const yargs = require('yargs')
 const deploy = require('../src')
 const pkg = require('../package.json')
@@ -45,7 +45,7 @@ const argv = yargs
             alias: 'pinner',
             choices: pinProviders,
             default: ['infura'],
-            describe: `Pinning services to which ${colors.brightWhite(
+            describe: `Pinning services to which ${chalk.whiteBright(
               'path'
             )} will be uploaded`
           },
@@ -61,23 +61,23 @@ const argv = yargs
         })
         .example(
           '$0',
-          `# Deploys relative path "${colors.brightWhite('public')}" to
-            ${colors.brightWhite('ipfs.infura.io/ipfs/<hash>')}; doesn't ` +
+          `# Deploys relative path "${chalk.whiteBright('public')}" to
+            ${chalk.whiteBright('ipfs.infura.io/ipfs/<hash>')}; doesn't ` +
             'update DNS; copies and opens URL. These defaults are chosen ' +
             'so as not to require signing up for any service or ' +
             'setting up environment variables on default use.'
         )
         .example(
           '$0 -p pinata _site',
-          `# Deploys path "${colors.brightWhite(
+          `# Deploys path "${chalk.whiteBright(
             '_site'
-          )}" ONLY to ${colors.brightWhite('pinata')} and doesn't update DNS`
+          )}" ONLY to ${chalk.whiteBright('pinata')} and doesn't update DNS`
         )
         .example(
           '$0 -p infura -p pinata -d cloudflare',
-          `# Deploys path "${colors.brightWhite(
+          `# Deploys path "${chalk.whiteBright(
             'public'
-          )}" to ${colors.brightWhite('pinata')} and ${colors.brightWhite(
+          )}" to ${chalk.whiteBright('pinata')} and ${chalk.whiteBright(
             'infura'
           )}, and updates cloudflare DNS`
         )

--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
   "dependencies": {
     "axios": "^0.21.1",
     "byte-size": "^7.0.1",
+    "chalk": "^4.1.1",
     "clipboardy": "^2.3.0",
-    "colors": "^1.4.0",
     "dnslink-cloudflare": "^3.0.0",
     "dnslink-dnsimple": "^1.0.1",
     "dotenv": "^10.0.0",

--- a/src/dnslink/maker.js
+++ b/src/dnslink/maker.js
@@ -1,14 +1,13 @@
 const ora = require('ora')
-const colors = require('colors/safe')
+const chalk = require('chalk')
 const { logError } = require('../logging')
-const white = colors.brightWhite
 
 module.exports = ({ name, validate, link }) => async (
   domain,
   hash,
   options
 ) => {
-  name = white(name)
+  name = chalk.whiteBright(name)
   const spinner = ora()
 
   try {
@@ -25,8 +24,8 @@ module.exports = ({ name, validate, link }) => async (
   try {
     const { record, value } = await link(domain, hash, options)
     spinner.succeed('🙌  SUCCESS!')
-    spinner.info(`🔄  Updated DNS TXT ${white(record)} to:`)
-    spinner.info(`🔗  ${white(value)}`)
+    spinner.info(`🔄  Updated DNS TXT ${chalk.whiteBright(record)} to:`)
+    spinner.info(`🔗  ${chalk.whiteBright(value)}`)
 
     return record
       .split('.')

--- a/src/guess-path.js
+++ b/src/guess-path.js
@@ -1,9 +1,7 @@
 const { existsSync } = require('fs')
 const ora = require('ora')
-const colors = require('colors/safe')
+const chalk = require('chalk')
 const isEmpty = require('lodash.isempty')
-
-const white = colors.brightWhite
 
 function guessedPath () {
   const guesses = [
@@ -26,13 +24,13 @@ module.exports = publicPath => {
   const spinner = ora()
 
   if (isEmpty(publicPath)) {
-    spinner.info(`🤔  No ${white('path')} argument specified. Looking for common ones…`)
+    spinner.info(`🤔  No ${chalk.whiteBright('path')} argument specified. Looking for common ones…`)
     result = guessedPath()
     if (result) {
-      spinner.succeed(`📂  Found local ${colors.blue(result)} directory. Deploying that.`)
+      spinner.succeed(`📂  Found local ${chalk.blueBright(result)} directory. Deploying that.`)
       return result
     } else {
-      spinner.fail(`🔮  Couldn't guess what to deploy. Please specify a ${white('path')}.`)
+      spinner.fail(`🔮  Couldn't guess what to deploy. Please specify a ${chalk.whiteBright('path')}.`)
       return undefined
     }
   } else {

--- a/src/pinners/maker.js
+++ b/src/pinners/maker.js
@@ -1,11 +1,10 @@
-const colors = require('colors/safe')
+const chalk = require('chalk')
 const { logger, logError } = require('../logging')
 const { linkCid } = require('../url-utils')
-const white = colors.brightWhite
 
 module.exports = ({ name, builder, pinDir, pinHash }) => async options => {
   const slug = name.toLowerCase()
-  name = white(name)
+  name = chalk.whiteBright(name)
   let api
 
   try {

--- a/src/show-size.js
+++ b/src/show-size.js
@@ -1,12 +1,12 @@
 const trammel = require('trammel')
 const byteSize = require('byte-size')
-const colors = require('colors/safe')
+const chalk = require('chalk')
 
 const { logger, logError } = require('./logging')
 
 module.exports = async (path, options) => {
   const log = logger(options)
-  log.start(`📦  Calculating size of ${colors.blue(path)}…`)
+  log.start(`📦  Calculating size of ${chalk.blueBright(path)}…`)
   try {
     const size = await trammel(path, {
       stopOnError: true,
@@ -15,7 +15,7 @@ module.exports = async (path, options) => {
     const kibi = byteSize(size, { units: 'iec' })
     const readableSize = `${kibi.value} ${kibi.unit}`
     log.succeed(
-      `🚚  Directory ${colors.blue(path)} weighs ${readableSize}.`
+      `🚚  Directory ${chalk.blueBright(path)} weighs ${readableSize}.`
     )
     return readableSize
   } catch (e) {

--- a/src/url-utils.js
+++ b/src/url-utils.js
@@ -1,5 +1,5 @@
 const terminalLink = require('terminal-link')
-const colors = require('colors/safe')
+const chalk = require('chalk')
 const ora = require('ora')
 const clipboardy = require('clipboardy')
 const doOpen = require('open')
@@ -17,11 +17,11 @@ const gatewayHttpUrl = (cid, gatewayProvider = 'ipfs') => {
   return cid ? `${origin}/ipfs/${cid}/` : origin
 }
 
-const linkCid = (cid, gatewayProvider) => `🔗  ${colors.green(
+const linkCid = (cid, gatewayProvider) => `🔗  ${chalk.green(
   terminalLink(cid, gatewayHttpUrl(cid, gatewayProvider))
 )}`
 
-const linkUrl = (url) => `🔗  ${colors.green(terminalLink(url, url))}`
+const linkUrl = (url) => `🔗  ${chalk.green(terminalLink(url, url))}`
 
 const openUrl = async (url) => {
   const spinner = ora()


### PR DESCRIPTION
`ora` already imports `chalk` and it does not pollute the String prototype.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>