### PR TITLE
breaking: consistently add hidden files to IPFS

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ There is an API so, however it is somewhat unstable and subject to change. Pleas
 
 ## Security
 
-We use `dotenv` to handle credentials. Don't commit your `.env` file to source
-control.
+- We use `dotenv` to handle credentials. Never commit your `.env` file to source control.
+- By default, we do **not** upload hidden files (dot files) to IPFS. If you are sure you want them to be added, use the flag `-H, --hidden`.
 
 ## Contributing
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -72,6 +72,12 @@ const argv = yargs
             describe: 'Only print the CID in the end',
             type: 'boolean',
             default: false
+          },
+          H: {
+            alias: 'hidden',
+            describe: 'Add hidden (dot) files to IPFS',
+            type: 'boolean',
+            default: false
           }
         })
         .example(
@@ -109,6 +115,7 @@ const options = {
 
   copyUrl: !argv.C,
   openUrls: argv.open,
+  hiddenFiles: argv.hidden,
 
   uploadServices: arrayFromString(argv.upload),
   pinningServices: arrayFromString(argv.pinner),

--- a/src/pinners/ipfs-cluster.js
+++ b/src/pinners/ipfs-cluster.js
@@ -7,6 +7,7 @@ const { getDirFormData } = require('./utils')
 
 /**
  * @typedef {import('./types').IPFSClusterOptions} IPFSClusterOptions
+ * @typedef {import('./types').PinDirOptions} PinDirOptions
  */
 
 class IpfsCluster {
@@ -27,11 +28,11 @@ class IpfsCluster {
 
   /**
    * @param {string} dir
-   * @param {string|undefined} tag
+   * @param {PinDirOptions|undefined} options
    * @returns {Promise<string>}
    */
-  async pinDir (dir, tag) {
-    const data = await getDirFormData(dir)
+  async pinDir (dir, { tag, hidden = false } = {}) {
+    const data = await getDirFormData(dir, hidden)
 
     const res = await axios
       .post(`${this.host}/add?name=${tag}`, data, {

--- a/src/pinners/ipfs-node.js
+++ b/src/pinners/ipfs-node.js
@@ -6,6 +6,7 @@ const path = require('path')
 
 /**
  * @typedef {import('ipfs-http-client').Options} IpfsOptions
+ * @typedef {import('./types').PinDirOptions} PinDirOptions
  */
 
 class IpfsNode {
@@ -18,11 +19,11 @@ class IpfsNode {
 
   /**
    * @param {string} dir
-   * @param {string|undefined} tag
+   * @param {PinDirOptions|undefined} options
    * @returns {Promise<string>}
    */
-  async pinDir (dir, tag) {
-    const response = await all(this.ipfs.addAll(globSource(dir, { recursive: true })))
+  async pinDir (dir, { tag, hidden = false } = {}) {
+    const response = await all(this.ipfs.addAll(globSource(dir, { recursive: true, hidden })))
     const basename = path.basename(dir)
     const root = response.find(({ path }) => path === basename)
 

--- a/src/pinners/pinata.js
+++ b/src/pinners/pinata.js
@@ -6,6 +6,7 @@ const { getDirFormData } = require('./utils')
 
 /**
  * @typedef {import('./types').PinataOptions} PinataOptions
+ * @typedef {import('./types').PinDirOptions} PinDirOptions
  */
 
 const MAX_RETRIES = 3
@@ -30,11 +31,11 @@ class Pinata {
 
   /**
    * @param {string} dir
-   * @param {string|undefined} tag
+   * @param {PinDirOptions|undefined} options
    * @returns {Promise<string>}
    */
-  async pinDir (dir, tag) {
-    const data = await getDirFormData(dir)
+  async pinDir (dir, { tag, hidden = false } = {}) {
+    const data = await getDirFormData(dir, hidden)
     const metadata = JSON.stringify({ name: tag })
     data.append('pinataMetadata', metadata)
 

--- a/src/pinners/types.ts
+++ b/src/pinners/types.ts
@@ -1,5 +1,10 @@
+export interface PinDirOptions {
+  tag?: string
+  hidden?: boolean
+}
+
 export interface PinningService {
-  pinDir: (dir: string, tag: string|undefined) => Promise<string>
+  pinDir: (dir: string, options: PinDirOptions|undefined) => Promise<string>
   pinCid: (cid: string, tag: string|undefined) => void
   gatewayUrl: (cid: string) => string
   displayName: string

--- a/src/pinners/utils.js
+++ b/src/pinners/utils.js
@@ -6,12 +6,13 @@ const { globSource } = require('ipfs-http-client')
 
 /**
  * @param {string} dir
+ * @param {boolean} hidden
  * @returns {Promise<FormData>}
  */
-async function getDirFormData (dir) {
+async function getDirFormData (dir, hidden) {
   const data = new FormData()
 
-  for await (const file of globSource(dir, { recursive: true })) {
+  for await (const file of globSource(dir, { recursive: true, hidden })) {
     // @ts-ignore
     if (file.content) {
       // @ts-ignore

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,7 @@ export interface DeployOptions {
   cid?: string
   tag?: string
 
+  hiddenFiles?: boolean
   copyUrl?: boolean
   openUrls?: boolean
 


### PR DESCRIPTION
This is both a fix and a new feature. It fixes #193 by consistently adding (or not) hidden files to all IPFS pinning services. By default, they are **not** added. I introduced a new flag ` -H, --hidden` to include dot files.

It is also a breaking change in terms of API. So v10.0.0 needs to be released after merging this.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>