### PR TITLE
fix: output logs to stderr

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -155,6 +155,12 @@ const options = {
       username: argv.fission && argv.fission.username,
       password: argv.fission && argv.fission.password
     }
+  },
+
+  logger: {
+    info: argv.quiet ? () => {} : console.error,
+    error: console.error,
+    out: console.log
   }
 }
 
@@ -162,21 +168,12 @@ if (!options.uploadServices && !options.pinningServices) {
   options.pinningServices = ['infura']
 }
 
-if (!argv.quiet) {
-  options.logger = {
-    info: console.log,
-    error: console.error
-  }
-}
-
 async function main () {
   try {
-    const cid = await deploy(options)
-    if (!argv.quiet) console.log() // Add an empty line
-    console.log(cid)
+    await deploy(options)
   } catch (e) {
-    console.error('❌  An error has occurred:\n')
-    console.error(e.stack || e.toString())
+    options.logger.error('❌  An error has occurred:\n')
+    options.logger.error(e.stack || e.toString())
     process.exit(1)
   }
 }

--- a/src/deploy.js
+++ b/src/deploy.js
@@ -124,7 +124,8 @@ function openUrlsBrowser (gatewayUrls, hostnames, logger) {
 
 const dummyLogger = /** @type {Logger} */({
   info: () => {},
-  error: () => {}
+  error: () => {},
+  out: () => {}
 })
 
 /**
@@ -254,6 +255,7 @@ async function deploy ({
     copyToClipboard(hostnames, gatewayUrls, logger)
   }
 
+  logger.out(cid)
   return cid
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,10 @@
 export interface Logger {
+  // For informational messages.
   info: (message: string) => void
+  // For error messages.
   error: (message: string) => void
+  // For program output.
+  out: (message: string) => void
 }
 
 export interface DeployOptions {


### PR DESCRIPTION
Fixes #215.

There was a regression compared to v8, where we now output to `stderr` by mistake. This PR introduce introduces a function `.out` to the logger object, so we now have:

- `.out` for program output
- `.info` for informational messages such as logs
- `.error` for errors

The defaults for `.info` and `.error` are `stderr`, while `.out` is `stdout`. This allows for developers importing the package to completely turn off logging or customize it as their need too.

If the option `-q, --quiet` is passed, then `.info` does nothing. 

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>