### PR TITLE
Switch to ESM and fix Node 19 compatibility

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,6 @@
 {
-  "extends": "ipfs"
+  "extends": "ipfs",
+  "parserOptions": {
+    "sourceType": "module"
+  }
 }

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [16.x, 18.x]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}

--- a/md/api.md
+++ b/md/api.md
@@ -3,8 +3,10 @@
 We've been trying to make `ipfs-deploy` more friendly as a library. However, we
 have no documentation yet.
 
+This library is only available in ESM format.
+
 ```javascript
-const { deploy, dnsLinkers, dnsLinkersMap, pinners, pinnersMap} = require('ipfs-deploy')
+import { deploy, dnsLinkers, dnsLinkersMap, pinners, pinnersMap } from 'ipfs-deploy'
 
 // Get available dnsLinkers identifiers
 dnsLinkersMap.keys()
@@ -21,7 +23,7 @@ dnsLinkersMap.get('cloudflare')
 How we currently use the deploy function:
 
 ```javascript
-const { deploy } = require('ipfs-deploy')
+import { deploy } from 'ipfs-deploy'
 
 const cid = await deploy({
   dir: argv.path,

--- a/md/contributing.md
+++ b/md/contributing.md
@@ -25,9 +25,7 @@ with the name of the pinning service. Let's say it's called `PinningService`:
 create a file at `src/pinners/pinning-service.js` with the following contents:
 
 ```javascript
-'use strict'
-
-class PinningService {
+export default class PinningService {
   constructor () {
     // TODO
   }
@@ -52,8 +50,6 @@ class PinningService {
     return 'pinning-service'
   }
 }
-
-module.exports = PinningService
 ```
 
 Where `options` in the constructor are the required parameters to connect to
@@ -69,7 +65,7 @@ the name of the DNS provider. Let's say it's called `DNS Provider`: create a
 file at `src/dnslinkers/dns-provider.js` with the following contents:
 
 ```javascript
-class DNSProvider {
+export default class DNSProvider {
   constructor () {
     // TODO
   }
@@ -94,9 +90,6 @@ class DNSProvider {
     return 'dns-provider'
   }
 }
-
-module.exports = DNSProvider
-
 ```
 
 Where `options` in the constructor are the required parameters to connect to

--- a/package.json
+++ b/package.json
@@ -22,8 +22,15 @@
     "src",
     "dist"
   ],
+  "type": "module",
   "main": "src/index.js",
   "types": "dist/src/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/src/index.d.ts",
+      "import": "./src/index.js"
+    }
+  },
   "typesVersions": {
     "*": {
       "src/*": [
@@ -44,8 +51,8 @@
     "url": "https://github.com/ipfs-shipyard/ipfs-deploy.git"
   },
   "scripts": {
-    "lint": "aegir lint && aegir ts -p check",
-    "test": "aegir test",
+    "lint": "aegir lint",
+    "test": "aegir test -t node -- --loader=esmock",
     "types": "aegir ts -p types",
     "release": "aegir release -t node",
     "release-minor": "aegir release --type minor",
@@ -68,7 +75,7 @@
   "dependencies": {
     "@aws-sdk/client-route-53": "^3.53.0",
     "@filebase/client": "^0.0.2",
-    "axios": "^0.26.0",
+    "axios": "^1.2.6",
     "byte-size": "^8.1.0",
     "chalk": "^4.1.1",
     "clipboardy": "^2.3.0",
@@ -78,7 +85,7 @@
     "dreamhost": "^1.0.5",
     "files-from-path": "^0.2.6",
     "form-data": "^4.0.0",
-    "ipfs-http-client": "^50.1.0",
+    "ipfs-http-client": "^60.0.0",
     "it-all": "^1.0.6",
     "lodash.isempty": "^4.4.0",
     "lodash.isstring": "^4.0.1",
@@ -91,12 +98,11 @@
   "devDependencies": {
     "@types/lodash.isempty": "^4.4.6",
     "@types/lodash.isstring": "^4.0.1",
-    "@types/proxyquire": "^1.3.28",
-    "aegir": "^33.2.0",
-    "proxyquire": "^2.1.3"
+    "aegir": "^38.1.0",
+    "esmock": "^2.1.0"
   },
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=16.0.0"
   },
   "contributors": [
     "Henrique Dias <hacdias@gmail.com>",

--- a/src/cli.js
+++ b/src/cli.js
@@ -3,14 +3,17 @@
 // @ts-nocheck
 
 /* eslint-disable no-console */
-'use strict'
 
-const updateNotifier = require('update-notifier')
-const yargs = require('yargs')
-const dotenv = require('dotenv')
+import { readFile } from 'node:fs/promises'
+import updateNotifier from 'update-notifier'
+import yargs from 'yargs/yargs'
+import { hideBin } from 'yargs/helpers'
+import dotenv from 'dotenv'
 
-const { deploy, dnsLinkersMap, pinnersMap } = require('.')
-const pkg = require('../package.json')
+import { deploy, dnsLinkersMap, pinnersMap } from './index.js'
+
+const pkgUrl = new URL('../package.json', import.meta.url)
+const pkg = JSON.parse(await readFile(pkgUrl, 'utf8'))
 
 const dnsProviders = [...dnsLinkersMap.keys()]
 const pinningServices = [...pinnersMap.keys()]
@@ -18,7 +21,7 @@ const pinningServices = [...pinnersMap.keys()]
 updateNotifier({ pkg, updateCheckInterval: 0 }).notify()
 dotenv.config()
 
-const argv = yargs
+const argv = yargs(hideBin(process.argv))
   .scriptName('ipfs-deploy')
   .usage(
     '$0 [path] [options]',

--- a/src/dnslinkers/cloudflare.js
+++ b/src/dnslinkers/cloudflare.js
@@ -1,15 +1,13 @@
-'use strict'
-
 // @ts-ignore
-const dnslink = require('dnslink-cloudflare')
-const isEmpty = require('lodash.isempty')
+import dnslink from 'dnslink-cloudflare'
+import isEmpty from 'lodash.isempty'
 
 /**
- * @typedef {import('./types').DNSRecord} DNSRecord
- * @typedef {import('./types').CloudflareOptions} CloudflareOptions
+ * @typedef {import('./types.js').DNSRecord} DNSRecord
+ * @typedef {import('./types.js').CloudflareOptions} CloudflareOptions
  */
 
-class Cloudflare {
+export default class Cloudflare {
   /**
    * @param {CloudflareOptions} options
    */
@@ -64,5 +62,3 @@ class Cloudflare {
     return 'cloudflare'
   }
 }
-
-module.exports = Cloudflare

--- a/src/dnslinkers/dnsimple.js
+++ b/src/dnslinkers/dnsimple.js
@@ -1,15 +1,13 @@
-'use strict'
-
 // @ts-ignore
-const dnslink = require('dnslink-dnsimple')
-const isEmpty = require('lodash.isempty')
+import dnslink from 'dnslink-dnsimple'
+import isEmpty from 'lodash.isempty'
 
 /**
- * @typedef {import('./types').DNSRecord} DNSRecord
- * @typedef {import('./types').DNSimpleOptions} DNSimpleOptions
+ * @typedef {import('./types.js').DNSRecord} DNSRecord
+ * @typedef {import('./types.js').DNSimpleOptions} DNSimpleOptions
  */
 
-class DNSimple {
+export default class DNSimple {
   /**
    * @param {DNSimpleOptions} options
    */
@@ -63,5 +61,3 @@ class DNSimple {
     return 'dnsimple'
   }
 }
-
-module.exports = DNSimple

--- a/src/dnslinkers/dreamhost.js
+++ b/src/dnslinkers/dreamhost.js
@@ -1,15 +1,13 @@
-'use strict'
-
 // @ts-ignore
-const DreamHostClient = require('dreamhost')
-const isEmpty = require('lodash.isempty')
+import DreamHostClient from 'dreamhost'
+import isEmpty from 'lodash.isempty'
 
 /**
- * @typedef {import('./types').DNSRecord} DNSRecord
- * @typedef {import('./types').DreamHostOptions} DreamHostOptions
+ * @typedef {import('./types.js').DNSRecord} DNSRecord
+ * @typedef {import('./types.js').DreamHostOptions} DreamHostOptions
  */
 
-class DreamHost {
+export default class DreamHost {
   /**
    * @param {DreamHostOptions} options
    */
@@ -80,5 +78,3 @@ class DreamHost {
     return 'dreamhost'
   }
 }
-
-module.exports = DreamHost

--- a/src/dnslinkers/index.js
+++ b/src/dnslinkers/index.js
@@ -1,18 +1,11 @@
-'use strict'
+import Cloudflare from './cloudflare.js'
+import DNSimple from './dnsimple.js'
+import DreamHost from './dreamhost.js'
+import Route53 from './route53.js'
 
-const Cloudflare = require('./cloudflare')
-const DNSimple = require('./dnsimple')
-const DreamHost = require('./dreamhost')
-const Route53 = require('./route53')
+export const dnsLinkers = [Cloudflare, DNSimple, DreamHost, Route53]
 
-const dnsLinkers = [Cloudflare, DNSimple, DreamHost, Route53]
-
-const dnsLinkersMap = dnsLinkers.reduce((map, dnsLinker) => {
+export const dnsLinkersMap = dnsLinkers.reduce((map, dnsLinker) => {
   map.set(dnsLinker.slug, dnsLinker)
   return map
 }, new Map())
-
-module.exports = {
-  dnsLinkers,
-  dnsLinkersMap
-}

--- a/src/dnslinkers/route53.js
+++ b/src/dnslinkers/route53.js
@@ -1,17 +1,15 @@
-'use strict'
-
 // @ts-ignore
 
-const { Route53Client, ChangeResourceRecordSetsCommand } = require('@aws-sdk/client-route-53')
-const isEmpty = require('lodash.isempty')
+import { Route53Client, ChangeResourceRecordSetsCommand } from '@aws-sdk/client-route-53'
+import isEmpty from 'lodash.isempty'
 const TTL = 60
 
 /**
- * @typedef {import('./types').DNSRecord} DNSRecord
- * @typedef {import('./types').Route53Options} Route53Options
+ * @typedef {import('./types.js').DNSRecord} DNSRecord
+ * @typedef {import('./types.js').Route53Options} Route53Options
  */
 
-class Route53 {
+export default class Route53 {
   /**
    * @param {Route53Options} options
    */
@@ -48,7 +46,7 @@ class Route53 {
             ResourceRecordSet: {
               Name: this.record,
               Type: 'TXT',
-              TTL: TTL,
+              TTL,
               ResourceRecords: [
                 {
                   Value: `"${txtValue}"`
@@ -80,5 +78,3 @@ class Route53 {
     return 'route53'
   }
 }
-
-module.exports = Route53

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,3 @@
-'use strict'
-
-const { dnsLinkers, dnsLinkersMap } = require('./dnslinkers')
-const { pinners, pinnersMap } = require('./pinners')
-const deploy = require('./deploy')
-
-module.exports = {
-  deploy,
-  dnsLinkers,
-  dnsLinkersMap,
-  pinners,
-  pinnersMap
-}
+export { dnsLinkers, dnsLinkersMap } from './dnslinkers/index.js'
+export { pinners, pinnersMap } from './pinners/index.js'
+export { default as deploy } from './deploy.js'

--- a/src/pinners/c4rex.js
+++ b/src/pinners/c4rex.js
@@ -1,8 +1,6 @@
-'use strict'
+import IpfsNode from './ipfs-node.js'
 
-const IpfsNode = require('./ipfs-node')
-
-class c4rex extends IpfsNode {
+export default class c4rex extends IpfsNode {
   constructor () {
     super({
       host: 'api.ipfs.c4rex.co',
@@ -31,5 +29,3 @@ class c4rex extends IpfsNode {
     return 'c4rex'
   }
 }
-
-module.exports = c4rex

--- a/src/pinners/dappnode.js
+++ b/src/pinners/dappnode.js
@@ -1,8 +1,6 @@
-'use strict'
+import IpfsNode from './ipfs-node.js'
 
-const IpfsNode = require('./ipfs-node')
-
-class DAppNode extends IpfsNode {
+export default class DAppNode extends IpfsNode {
   constructor () {
     super({
       host: 'ipfs.dappnode',
@@ -23,5 +21,3 @@ class DAppNode extends IpfsNode {
     return 'dappnode'
   }
 }
-
-module.exports = DAppNode

--- a/src/pinners/filebase.js
+++ b/src/pinners/filebase.js
@@ -1,18 +1,18 @@
-'use strict'
-
-const isEmpty = require('lodash.isempty')
-const { FilebaseClient } = require('@filebase/client')
-const { filesFromPath } = require('files-from-path')
-const { default: axios } = require('axios')
+import isEmpty from 'lodash.isempty'
+// @ts-ignore
+import { FilebaseClient } from '@filebase/client'
+// @ts-ignore
+import { filesFromPath } from 'files-from-path'
+import axios from 'axios'
 
 /**
- * @typedef {import('./types').FilebaseOptions} FilebaseOptions
- * @typedef {import('./types').PinDirOptions} PinDirOptions
+ * @typedef {import('./types.js').FilebaseOptions} FilebaseOptions
+ * @typedef {import('./types.js').PinDirOptions} PinDirOptions
  */
 
 const PIN_HASH_URL = 'https://api.filebase.io/v1/ipfs/pins'
 
-class Filebase {
+export default class Filebase {
   /**
    * @param {FilebaseOptions} options
    */
@@ -24,7 +24,7 @@ class Filebase {
     this.auth = {
       api_key: apiKey,
       secret_api_key: secretApiKey,
-      bucket: bucket
+      bucket
     }
 
     this.tokenString = btoa(`${this.auth.api_key}:${this.auth.secret_api_key}:${this.auth.bucket}`)
@@ -57,7 +57,7 @@ class Filebase {
    */
   async pinCid (cid, tag) {
     const body = JSON.stringify({
-      cid: cid,
+      cid,
       name: tag
     })
 
@@ -91,5 +91,3 @@ class Filebase {
     return 'filebase'
   }
 }
-
-module.exports = Filebase

--- a/src/pinners/index.js
+++ b/src/pinners/index.js
@@ -1,27 +1,21 @@
-'use strict'
+import DAppNode from './dappnode.js'
+import Infura from './infura.js'
+import IpfsCluster from './ipfs-cluster.js'
+import Pinata from './pinata.js'
+import c4rex from './c4rex.js'
+// Disabled for now as '@filebase/client' dependency doesn't work in ESM mode yet.
+// import Filebase from './filebase.js'
 
-const DAppNode = require('./dappnode')
-const Infura = require('./infura')
-const IpfsCluster = require('./ipfs-cluster')
-const Pinata = require('./pinata')
-const c4rex = require('./c4rex')
-const Filebase = require('./filebase')
-
-const pinners = [
+export const pinners = [
   DAppNode,
   Infura,
   IpfsCluster,
   Pinata,
-  c4rex,
-  Filebase
+  c4rex
+  // Filebase
 ]
 
-const pinnersMap = pinners.reduce((map, pinner) => {
+export const pinnersMap = pinners.reduce((map, pinner) => {
   map.set(pinner.slug, pinner)
   return map
 }, new Map())
-
-module.exports = {
-  pinners,
-  pinnersMap
-}

--- a/src/pinners/infura.js
+++ b/src/pinners/infura.js
@@ -1,14 +1,12 @@
-'use strict'
-
-const isString = require('lodash.isstring')
-const IpfsNode = require('./ipfs-node')
+import isString from 'lodash.isstring'
+import IpfsNode from './ipfs-node.js'
 
 /**
  * @typedef {import('ipfs-http-client').Options} IpfsOptions
- * @typedef {import('./types').InfuraOptions} InfuraOptions
+ * @typedef {import('./types.js').InfuraOptions} InfuraOptions
  */
 
-class Infura extends IpfsNode {
+export default class Infura extends IpfsNode {
   /**
    * @param {InfuraOptions} options
    */
@@ -46,5 +44,3 @@ class Infura extends IpfsNode {
     return 'infura'
   }
 }
-
-module.exports = Infura

--- a/src/pinners/ipfs-cluster.js
+++ b/src/pinners/ipfs-cluster.js
@@ -1,16 +1,13 @@
-'use strict'
-
-const { default: axios } = require('axios')
-const path = require('path')
-const isEmpty = require('lodash.isempty')
-const { getDirFormData } = require('./utils')
+import axios from 'axios'
+import isEmpty from 'lodash.isempty'
+import { getDirFormData } from './utils.js'
 
 /**
- * @typedef {import('./types').IPFSClusterOptions} IPFSClusterOptions
- * @typedef {import('./types').PinDirOptions} PinDirOptions
+ * @typedef {import('./types.js').IPFSClusterOptions} IPFSClusterOptions
+ * @typedef {import('./types.js').PinDirOptions} PinDirOptions
  */
 
-class IpfsCluster {
+export default class IpfsCluster {
   /**
    *
    * @param {IPFSClusterOptions} options
@@ -32,7 +29,7 @@ class IpfsCluster {
    * @returns {Promise<string>}
    */
   async pinDir (dir, { tag, hidden = false } = {}) {
-    const data = await getDirFormData(dir, hidden)
+    const data = await getDirFormData(dir, hidden, 'upload')
 
     const res = await axios
       .post(`${this.host}/add?name=${tag}`, data, {
@@ -50,9 +47,8 @@ class IpfsCluster {
       .split('\n')
       .map(JSON.parse)
 
-    const basename = path.basename(dir)
     // @ts-ignore
-    const root = results.find(({ name }) => name === basename)
+    const root = results.find(({ name }) => name === 'upload')
 
     if (!root) {
       throw new Error('could not determine the CID')
@@ -93,5 +89,3 @@ class IpfsCluster {
     return 'ipfs-cluster'
   }
 }
-
-module.exports = IpfsCluster

--- a/src/pinners/pinata.js
+++ b/src/pinners/pinata.js
@@ -1,12 +1,10 @@
-'use strict'
-
-const { default: axios } = require('axios')
-const isEmpty = require('lodash.isempty')
-const { getDirFormData } = require('./utils')
+import axios from 'axios'
+import isEmpty from 'lodash.isempty'
+import { getDirFormData } from './utils.js'
 
 /**
- * @typedef {import('./types').PinataOptions} PinataOptions
- * @typedef {import('./types').PinDirOptions} PinDirOptions
+ * @typedef {import('./types.js').PinataOptions} PinataOptions
+ * @typedef {import('./types.js').PinDirOptions} PinDirOptions
  */
 
 const MAX_RETRIES = 3
@@ -14,7 +12,7 @@ const RETRY_CODES = [429]
 const PIN_DIR_URL = 'https://api.pinata.cloud/pinning/pinFileToIPFS'
 const PIN_HASH_URL = 'https://api.pinata.cloud/pinning/pinByHash'
 
-class Pinata {
+export default class Pinata {
   /**
    * @param {PinataOptions} options
    */
@@ -55,7 +53,7 @@ class Pinata {
           })
 
         return res.data.IpfsHash
-      } catch (err) {
+      } catch (/** @type {any} */ err) {
         if (err && err.response && RETRY_CODES.includes(err.response.status)) {
           retries += 1
           lastErrorCode = err.response.status
@@ -111,5 +109,3 @@ class Pinata {
     return 'pinata'
   }
 }
-
-module.exports = Pinata

--- a/src/pinners/types.ts
+++ b/src/pinners/types.ts
@@ -4,8 +4,8 @@ export interface PinDirOptions {
 }
 
 export interface PinningService {
-  pinDir: (dir: string, options: PinDirOptions|undefined) => Promise<string>
-  pinCid: (cid: string, tag: string|undefined) => void
+  pinDir: (dir: string, options: PinDirOptions | undefined) => Promise<string>
+  pinCid: (cid: string, tag: string | undefined) => void
   gatewayUrl: (cid: string) => string
   displayName: string
 }

--- a/src/pinners/utils.js
+++ b/src/pinners/utils.js
@@ -1,30 +1,24 @@
-'use strict'
-
-const FormData = require('form-data')
-const path = require('path')
-const { globSource } = require('ipfs-http-client')
+import FormData from 'form-data'
+import { globSource } from 'ipfs-http-client'
 
 /**
  * @param {string} dir
  * @param {boolean} hidden
+ * @param {string} pathPrefix
  * @returns {Promise<FormData>}
  */
-async function getDirFormData (dir, hidden) {
+export async function getDirFormData (dir, hidden, pathPrefix = '') {
   const data = new FormData()
 
-  for await (const file of globSource(dir, { recursive: true, hidden })) {
+  for await (const file of globSource(dir, '**/*', { hidden })) {
     // @ts-ignore
     if (file.content) {
       // @ts-ignore
       data.append('file', file.content, {
-        filepath: path.normalize(file.path)
+        filepath: pathPrefix + file.path
       })
     }
   }
 
   return data
-}
-
-module.exports = {
-  getDirFormData
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,12 +1,10 @@
-'use strict'
-
-const { existsSync } = require('fs')
+import { existsSync } from 'node:fs'
 // @ts-ignore
-const trammel = require('trammel')
+import trammel from 'trammel'
 // @ts-ignore
-const byteSize = require('byte-size')
-const terminalLink = require('terminal-link')
-const chalk = require('chalk')
+import byteSize from 'byte-size'
+import terminalLink from 'terminal-link'
+import chalk from 'chalk'
 
 const pathsToCheck = [
   '_site', // jekyll, hakyll, eleventy
@@ -25,7 +23,7 @@ const pathsToCheck = [
  *
  * @returns {string}
  */
-function guessPath () {
+export function guessPath () {
   const guesses = pathsToCheck.filter(existsSync)
   if (guesses.length > 1) {
     throw new Error('more than one guessable path to deploy, please specify a path')
@@ -44,7 +42,7 @@ function guessPath () {
  * @param {string} path
  * @returns {Promise<string>}
  */
-async function getReadableSize (path) {
+export async function getReadableSize (path) {
   const size = await trammel(path, {
     stopOnError: true,
     type: 'raw'
@@ -62,12 +60,6 @@ async function getReadableSize (path) {
  * @param {string} link
  * @returns {string}
  */
-function terminalUrl (title, link) {
+export function terminalUrl (title, link) {
   return `🔗  ${chalk.green(terminalLink(title, link))}`
-}
-
-module.exports = {
-  guessPath,
-  getReadableSize,
-  terminalUrl
 }

--- a/test/dnslinkers/cloudflare.spec.js
+++ b/test/dnslinkers/cloudflare.spec.js
@@ -1,11 +1,10 @@
 /* eslint max-nested-callbacks: ["error", 8] */
 /* eslint-env mocha */
-'use strict'
 
-const { expect } = require('aegir/utils/chai')
-const proxyquire = require('proxyquire').noCallThru()
+import { expect } from 'aegir/chai'
+import esmock from 'esmock'
 
-const Cloudflare = proxyquire('../../src/dnslinkers/cloudflare', {
+const Cloudflare = await esmock('../../src/dnslinkers/cloudflare.js', {
   'dnslink-cloudflare': () => 'value'
 })
 

--- a/test/dnslinkers/dnsimple.spec.js
+++ b/test/dnslinkers/dnsimple.spec.js
@@ -1,11 +1,10 @@
 /* eslint max-nested-callbacks: ["error", 8] */
 /* eslint-env mocha */
-'use strict'
 
-const { expect } = require('aegir/utils/chai')
-const proxyquire = require('proxyquire').noCallThru()
+import { expect } from 'aegir/chai'
+import esmock from 'esmock'
 
-const DNSimple = proxyquire('../../src/dnslinkers/dnsimple', {
+const DNSimple = await esmock('../../src/dnslinkers/dnsimple.js', {
   // @ts-ignore
   'dnslink-dnsimple': (_token, { link }) => {
     return { record: { content: `dnslink=${link}` } }

--- a/test/pinners/ipfs-cluster.spec.js
+++ b/test/pinners/ipfs-cluster.spec.js
@@ -1,11 +1,10 @@
 /* eslint max-nested-callbacks: ["error", 8] */
 /* eslint-env mocha */
-'use strict'
 
-const { expect } = require('aegir/utils/chai')
-const proxyquire = require('proxyquire').noCallThru()
+import { expect } from 'aegir/chai'
+import esmock from 'esmock'
 
-const IpfsCluster = proxyquire('../../src/pinners/ipfs-cluster', {
+const IpfsCluster = await esmock('../../src/pinners/ipfs-cluster', {
   axios: {
     default: {
       post: async () => ({

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -1,12 +1,11 @@
 /* eslint max-nested-callbacks: ["error", 8] */
 /* eslint-env mocha */
-'use strict'
 
-const { expect } = require('aegir/utils/chai')
-const proxyquire = require('proxyquire').noCallThru()
+import { expect } from 'aegir/chai'
+import esmock from 'esmock'
 
-it('guessPath throws when cannot find any guessable path', () => {
-  const { guessPath } = proxyquire('../src/utils', {
+it('guessPath throws when cannot find any guessable path', async () => {
+  const { guessPath } = await esmock('../src/utils.js', {
     fs: {
       existsSync: () => false
     }
@@ -15,8 +14,8 @@ it('guessPath throws when cannot find any guessable path', () => {
   expect(guessPath).to.throw()
 })
 
-it('guessPath throws if more than one guessable path is available', () => {
-  const { guessPath } = proxyquire('../src/utils', {
+it('guessPath throws if more than one guessable path is available', async () => {
+  const { guessPath } = await esmock('../src/utils.js', {
     fs: {
       /**
        * @param {string} path
@@ -38,8 +37,8 @@ it('guessPath throws if more than one guessable path is available', () => {
   expect(guessPath).to.throw()
 })
 
-it('guessPath returns guessable path', () => {
-  const { guessPath } = proxyquire('../src/utils', {
+it('guessPath returns guessable path', async () => {
+  const { guessPath } = await esmock('../src/utils.js', {
     fs: {
       /**
        * @param {string} path

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "extends": "aegir/src/config/tsconfig.aegir.json",
   "compilerOptions": {
+    "module": "node16",
+    "moduleResolution": "node16",
     "outDir": "dist",
     "baseUrl": "./",
     "paths": {


### PR DESCRIPTION
Fixes #258.

In order to fix the Node 19 compatibility issue, the ipfs-http-client dependency needed to be upgraded from v50.1.0 to v60.0.0. However, [ipfs-http-client v57.0.0 went ESM only](https://github.com/ipfs/js-ipfs/blob/master/packages/ipfs-http-client/CHANGELOG.md#5700-2022-05-27), so upgrading to it either requires upgrading this project to ESM, or for the `require()` calls to load the library to be replaced with asynchronous `import()` calls. Using asynchronous `import()` calls would require some of the public API to be awkwardly reworked, so instead I upgraded the project to ESM.

In [ipfs-http-client v53.0.0](https://github.com/ipfs/js-ipfs/blob/master/packages/ipfs-http-client/CHANGELOG.md#5300-2021-09-24), the [`globSource` function had some subtle incompatible changes](https://github.com/ipfs/js-ipfs/pull/3889). One important difference is that the file paths returned by it no longer start with the upload directory's name but instead now start with "/" and are relative to the inside of the upload directory. In the places where we needed all of the results from `globSource` to be named as if they existed in a single wrapping directory, I prefixed `globSource`'s results with an arbitrary directory name ("upload").

Proxyquire, which was used in the tests to replace some dependencies with mocks, isn't compatible with Node ESM, so I replaced it with esmock, which was practically a drop-in replacement.

Axios was upgraded from ^0.26.0 to ^1.2.6 because the older version had an issue preventing it from working with Typescript and ESM together.

Aegir was upgraded from ^33 to ^38 for ESM compatibility. Aegir has combined the `aegir ts` command into `aegir lint` (https://github.com/ipfs/aegir/commit/e3a4b450c5eb271ae3557144d78636695751ce11), so package.json's scripts.lint value was simplified to just "aegir lint".

## Remaining work

This PR makes the library ESM-only, which is a breaking change for anyone using it as a library through `require()` calls, so this change should cause a major version bump.

There is one incomplete part of this PR: The `@filebase/client` library depends on an old fork of `ipfs-car` which is not ESM compatible, so this PR currently disables support for the Filebase pinning service. (TODO report issue to the library.) Either the docs should be updated to remove Filebase from the list of supported pinning services, or the support should be fixed.

This PR needs a bit more testing. I have tested this PR by uploading files to Infura and using the CloudFlare dns updater. The Pinata and IPFS Cluster pinning support were both impacted by the `globSource` changes so they ought to be tested by someone.