### PR TITLE
Fix: upload to ipfs-cluster

### DIFF
--- a/src/pinners/ipfs-cluster.js
+++ b/src/pinners/ipfs-cluster.js
@@ -58,7 +58,7 @@ class IpfsCluster {
       throw new Error('could not determine the CID')
     }
 
-    return root.cid['/']
+    return root.cid
   }
 
   /**


### PR DESCRIPTION
The response from ipfs

```json
{
  "name": "out",
  "cid": "QmQuKztD22yHKsqVCG8mwfrmxxxxx",
  "size": 8997343,
  "allocations": [ "12D3KooWNYut1XL31b4KUnCZmCxxxx" ]
}
```

So, `root.cid` is enough.